### PR TITLE
feat: fix list view timestamp positioning

### DIFF
--- a/src/components/icons/star.js
+++ b/src/components/icons/star.js
@@ -19,7 +19,7 @@ const Star = ({ size, height, width, fill, opacity, ...rest }) => (
 
 Star.defaultProps = {
   fill: '#639',
-  opacity: 0.25,
+  opacity: 0.15,
   width: 8,
   height: 8,
 }

--- a/src/components/message.js
+++ b/src/components/message.js
@@ -34,9 +34,7 @@ const Details = styled.div(
   },
   ({ showAction, theme }) => ({
     ...(showAction
-      ? {
-          paddingRight: 72,
-        }
+      ? {}
       : {
           backgroundColor: theme.name === 'dark' ? theme.bgDark : theme.bgLight,
         }),
@@ -45,10 +43,11 @@ const Details = styled.div(
 
 const To = styled.h2(
   {
-    margin: '0.25rem 0',
+    margin: 0,
     padding: 0,
     fontFamily: SYSTEM_FONTS.join(`,`),
     fontSize: 14,
+    lineHeight: 1.5,
     fontWeight: 'normal',
     whiteSpace: 'nowrap',
     overflow: 'hidden',
@@ -59,7 +58,13 @@ const To = styled.h2(
   })
 )
 
-const From = styled(To)()
+const From = styled(To)({}, ({ showAction, theme }) => ({
+  ...(showAction
+    ? {}
+    : {
+        paddingRight: 72,
+      }),
+}))
 
 const Date = styled(To)()
 
@@ -68,8 +73,9 @@ const Subject = styled(To)(
     fontSize: 16,
     fontWeight: 'bold',
   },
-  ({ theme }) => ({
+  ({ showAction, theme }) => ({
     color: theme.color,
+    ...(showAction ? {} : { paddingRight: 16 }),
   })
 )
 
@@ -82,7 +88,7 @@ const MessageContent = styled.div({
 const Action = styled.div(
   {
     position: `absolute`,
-    top: '50%',
+    top: '0.85rem',
     right: 8,
     transform: 'translateY(-50%)',
   },
@@ -127,7 +133,7 @@ function Message({ className, showAction, showTo, stripe, payload }) {
             <span css={{ fontSize: 12, marginRight: '0.5rem' }}>
               {format(date, 'MMM DD')}
             </span>
-            <MdArrowForward css={{ position: 'relative', top: 2 }} />
+            <MdArrowForward css={{ verticalAlign: 'sub' }} />
           </Action>
         )}
       </Content>


### PR DESCRIPTION
before/after:

![image](https://user-images.githubusercontent.com/21834/47327461-ad2d3300-d66d-11e8-950e-92720e19eb1a.png)

Not visible in the image above, but `From` still starts truncating at the right position. ;)