### PR TITLE
Defines the scoped required for the github token and updated the yarn and npm commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ A proof of concept application that demonstrates a few concepts, namely:
 ## 🚀 Set up
 
 - `yarn` or `npm install`
-- `cat .env.sample > .env.development`
-  - Request a [Github token](https://github.com/settings/tokens), and add to `.env.development`
-- `yarn start` or `npm start`
+- Request a [Github token](https://github.com/settings/tokens) give 'repo' full access to the token
+- `cat .env.sample > .env.development` then paste in your access token from gitub
+- `yarn develop` or `npm run develop`


### PR DESCRIPTION
Fixes #12 by adding a bit more details on what scopes need to be selected for the Github token. Also changed 'yarn start or npm start' to 'yarn develop or npm run develop' since those commands are not included in the package.json.