### PR TITLE
fix: removed expanded from query due to OpenGraph changes

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,5 @@
 # move this to .env.development to develop locally!
 # conversely .env.production if building locally
 GATSBY_OG_APP_ID=69b506c8-f9e6-4b44-9f91-8fcc1226b6f2
-GITHUB_API_TOKEN='' # https://github.com/settings/tokens
+# https://github.com/settings/tokens
+GITHUB_API_TOKEN=''

--- a/src/pages/threads.js
+++ b/src/pages/threads.js
@@ -27,21 +27,19 @@ function Threads({ location }) {
             google {
               gmail {
                 thread(id: $threadId) {
-                  expanded {
-                    messages {
-                      id
-                      payload {
-                        parts {
-                          mimeType
-                          body {
-                            data
-                          }
+                  messages {
+                    id
+                    payload {
+                      parts {
+                        mimeType
+                        body {
+                          data
                         }
-                        date
-                        subject
-                        from
-                        to
                       }
+                      date
+                      subject
+                      from
+                      to
                     }
                   }
                 }
@@ -52,9 +50,7 @@ function Threads({ location }) {
         variables={{ threadId: id }}
         children={({ loading, data }) => {
           const messages =
-            data && data.google
-              ? data.google.gmail.thread.expanded.messages
-              : null
+            data && data.google ? data.google.gmail.thread.messages : null
           return (
             <>
               {loading && (


### PR DESCRIPTION
Hi,

I created my own app id on OG to get gatsby-mail working. I then got an error "Field 'expanded' is not defined on type 'GmailThread'". And after using the data explorer in OG I found out 'expanded' is not there anymore between 'thread' and 'messages' :)

![image](https://user-images.githubusercontent.com/20125808/55106793-13602b00-50d0-11e9-94fd-ce9cb6562c06.png)

I have just started with React & Gatsby. And now that I have found out the combo also does "dynamic" I have so much more to learn hahaha

Kind regards,

Stefan
