### PR TITLE
Windows does not like a comment after the token

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,5 @@
 # move this to .env.development to develop locally!
 # conversely .env.production if building locally
 GATSBY_OG_APP_ID=69b506c8-f9e6-4b44-9f91-8fcc1226b6f2
-GITHUB_API_TOKEN='' # https://github.com/settings/tokens
+# https://github.com/settings/tokens
+GITHUB_API_TOKEN=''


### PR DESCRIPTION
I am on Windows and it took me some time to figure out why the github graphql query didn't work.
And Linux (or any other OS) probably won't mind the comment being on it's own line too.